### PR TITLE
Fix #26 and #27

### DIFF
--- a/js/channels.js
+++ b/js/channels.js
@@ -84,6 +84,14 @@ Channels.prototype.idFromIndex = function (index) {
     return hrefid.substr(hrefid.indexOf("-") + 1);
 }
 
+Channels.prototype.channelsByName = function () {
+    var that = this;
+
+    return Object.keys(this.names).map(function (value, index, array) {
+        return that.names[value];
+    })
+}
+
 function Channel(id, name) {
     this.id = id;
     this.name = name;
@@ -185,12 +193,16 @@ Channel.prototype.print = function (msg, html, noParse) {
                     pref = "<span class='player-message' style='color: " + players.color(id) + "'>" + pref + ":</span>";
                 }
 
-                msg = pref + msg.slice(msg.indexOf(":") + 1);
+                msg = pref + addChannelLinks(msg.slice(msg.indexOf(":") + 1));
             }
         }
     }
 
     chatTextArea.innerHTML += msg + "<br/>\n";
+
+    if (!html) {
+        parsePOLinks(chatTextArea, msg);
+    }
 
     /* Limit number of lines */
     if (this.chatCount++ % 500 === 0) {

--- a/js/formatting.js
+++ b/js/formatting.js
@@ -47,21 +47,6 @@ defineOn(String.prototype, {
                 ;
         });
     },
-    midRef: function (position, n) { // QStringRef QString::midRef
-        if (n == null || typeof n != "number")
-            n = -1;
-
-        var str = this;
-        var strlen = str.length - 1;
-        if (position > strlen)
-            return "";
-
-        var substri = str.substr(position);
-        if (n > strlen || n == -1)
-            return substri;
-
-        return substri.substr(0, n);
-    },
     replaceBetween: function (pos1, pos2, replace) { // QString QString::replace(int, int, QRegExp)
         var str = this;
         var returnStr = str;
@@ -197,7 +182,7 @@ function addChannelLinks(line2) { // Ported from PO
         var longestName = "";
         var longestChannelName = "";
         channels.channelsByName().forEach(function (name, index, array) {
-            var channelName = line.midRef(pos, name.length).toString();
+            var channelName = line.substr(pos, name.length).toString();
             var res = channelName.toLowerCase() == name.toLowerCase();
             if (res && longestName.length < channelName.length) {
                 longestName = name;

--- a/js/formatting.js
+++ b/js/formatting.js
@@ -48,12 +48,7 @@ defineOn(String.prototype, {
         });
     },
     replaceBetween: function (pos1, pos2, replace) { // QString QString::replace(int, int, QRegExp)
-        var str = this;
-        var returnStr = str;
-        var sub = str.substr(pos1, pos2);
-        returnStr = returnStr.replace(sub, replace);
-
-        return returnStr;
+        return this.slice(0,pos1) + replace + this.slice(pos2);
     }
 });
 

--- a/js/formatting.js
+++ b/js/formatting.js
@@ -47,8 +47,13 @@ defineOn(String.prototype, {
                 ;
         });
     },
-    splice: function (pos1, pos2, replace) { // QString QString::replace(int, int, QRegExp)
-        return this.slice(0,pos1) + replace + this.slice(pos2);
+    splice: function (pos1, pos2, replace) { // QString QString::replace(int, int, QString)
+        var str = this;
+        var returnStr = str;
+        var sub = str.substr(pos1, pos2);
+        returnStr = returnStr.replace(sub, replace);
+
+        return returnStr;
     }
 });
 
@@ -92,30 +97,15 @@ function convertPOLinks(element) {
 }
 
 function parsePOLinks(element, msg) {
-    return $(element, msg).find("a").each(function (index, url) {
-        url = $(url);
-        if (!url.attr("href")) {
-            return;
-        }
+    return $(element, msg).find("a[href^=\"po:\"]").click(function (event) {
+        var po = $(this)[0].pathname.split("/"); // Somewhat of a hack because this isn't documented.
+        var command = po[0];
+        var data = po[1];
 
-        var proto = url.attr("href").split(":")[0],
-            query = url.attr("href").split(":")[1];
-
-        switch (proto) {
-            case "po":
-                var po = query.split("/");
-                var command = po[0];
-                var data = po[1];
-
-                console.log(po, command, data);
-                // Add other commands here..
-                if (command === "join") {
-                    url.click(function (event) {
-                        joinChannel(data);
-                        event.preventDefault();
-                    });
-                }
-                break;
+        // Add other commands here..
+        if (command === "join") {
+            joinChannel(data);
+            event.preventDefault();
         }
     }).html();
 }
@@ -185,7 +175,6 @@ function addChannelLinks(line2) { // Ported from PO
             }
         });
         if (longestName) {
-            console.log("Channel found:", longestChannelName);
             var html = "<a href=\"po:join/" + escapeSlashes(longestName) + "\">#" + longestChannelName + "</a>";
             line = line.splice(pos - 1, longestName.length + 1, html);
             pos += html.length - 1;

--- a/js/formatting.js
+++ b/js/formatting.js
@@ -46,6 +46,29 @@ defineOn(String.prototype, {
                 : match
                 ;
         });
+    },
+    midRef: function (position, n) { // QStringRef QString::midRef
+        if (n == null || typeof n != "number")
+            n = -1;
+
+        var str = this;
+        var strlen = str.length - 1;
+        if (position > strlen)
+            return "";
+
+        var substri = str.substr(position);
+        if (n > strlen || n == -1)
+            return substri;
+
+        return substri.substr(0, n);
+    },
+    replaceBetween: function (pos1, pos2, replace) { // QString QString::replace(int, int, QRegExp)
+        var str = this;
+        var returnStr = str;
+        var sub = str.substr(pos1, pos2);
+        returnStr = returnStr.replace(sub, replace);
+
+        return returnStr;
     }
 });
 
@@ -53,7 +76,7 @@ function convertPOLinks(element) {
     $(element).find("img").each(function (index, img) {
         img = $(img);
         var proto = img.attr("src").split(":")[0],
-            query = img.attr("src").split(":")[1]
+            query = img.attr("src").split(":")[1];
 
         switch (proto) {
             case "pokemon":
@@ -86,6 +109,35 @@ function convertPOLinks(element) {
                 break;
         }
     });
+}
+
+function parsePOLinks(element, msg) {
+    return $(element, msg).find("a").each(function (index, url) {
+        url = $(url);
+        if (!url.attr("href")) {
+            return;
+        }
+
+        var proto = url.attr("href").split(":")[0],
+            query = url.attr("href").split(":")[1];
+
+        switch (proto) {
+            case "po":
+                var po = query.split("/");
+                var command = po[0];
+                var data = po[1];
+
+                console.log(po, command, data);
+                // Add other commands here..
+                if (command === "join") {
+                    url.click(function (event) {
+                        joinChannel(data);
+                        event.preventDefault();
+                    });
+                }
+                break;
+        }
+    }).html();
 }
 
 function pokemonPictureUrl(pokeid, gen, gender, shiny, back) {
@@ -123,6 +175,47 @@ function format(element) {
     }
 }
 
+function addChannelLinks(line2) { // Ported from PO
+    // * Optimize/clean this up
+
+    line2 = line2.toString(); // Just to be sure.
+
+    // Channels don't have to be collected if there are no channel links
+    // Strips html because tags can have hex colors.
+    if (stripHtml(line2).indexOf("#") === -1) {
+        return line2;
+    }
+
+    // make a mutable copy
+    var line = line2;
+    /* scan for channel links */
+    var pos = 0;
+    pos = line.indexOf('#', pos);
+
+    while (pos != -1) {
+        ++pos;
+        var longestName = "";
+        var longestChannelName = "";
+        channels.channelsByName().forEach(function (name, index, array) {
+            var channelName = line.midRef(pos, name.length).toString();
+            var res = channelName.toLowerCase() == name.toLowerCase();
+            if (res && longestName.length < channelName.length) {
+                longestName = name;
+                longestChannelName = channelName;
+            }
+        });
+        if (longestName) {
+            console.log("Channel found:", longestChannelName);
+            var html = "<a href=\"po:join/" + escapeSlashes(longestName) + "\">#" + longestChannelName + "</a>";
+            line = line.replaceBetween(pos - 1, longestName.length + 1, html);
+            pos += html.length - 1;
+            console.log("Line: ", line);
+        }
+        pos = line.indexOf('#', pos);
+    }
+    return line;
+}
+
 /* Ported from PO */
 function escapeHtml(toConvert)
 {
@@ -137,4 +230,18 @@ function escapeHtml(toConvert)
 
 
     return ret;
+}
+
+
+function stripHtml(str)
+{
+    return str.replace(/<\/?[^>]*>/g, "");
+}
+
+function escapeSlashes(str) {
+    return str.replace(/'/g, "&apos;").replace(/"/g, '&quot;');
+}
+
+function unescapeSlashes(str) {
+    return str.replace(/&apos;/g, "'").replace(/&quot;/g, '"');
 }

--- a/js/formatting.js
+++ b/js/formatting.js
@@ -47,7 +47,7 @@ defineOn(String.prototype, {
                 ;
         });
     },
-    replaceBetween: function (pos1, pos2, replace) { // QString QString::replace(int, int, QRegExp)
+    splice: function (pos1, pos2, replace) { // QString QString::replace(int, int, QRegExp)
         return this.slice(0,pos1) + replace + this.slice(pos2);
     }
 });
@@ -187,7 +187,7 @@ function addChannelLinks(line2) { // Ported from PO
         if (longestName) {
             console.log("Channel found:", longestChannelName);
             var html = "<a href=\"po:join/" + escapeSlashes(longestName) + "\">#" + longestChannelName + "</a>";
-            line = line.replaceBetween(pos - 1, longestName.length + 1, html);
+            line = line.splice(pos - 1, longestName.length + 1, html);
             pos += html.length - 1;
             console.log("Line: ", line);
         }


### PR DESCRIPTION
I know that these are two different issues, but they are closely connected. Plus, doing #26 at the same time made testing it a lot easier.

unescapeSlashes is currently unused, but it's still a pretty useful utility function if you want to undo escapeSlashes.

Possible problems with the usage of .click (didn't encounter these when testing):
It could attach itself to messages which are the same. Usage of var selector = $("selector"); selector = selector[selector.length -1] should fix this (because the new message will always be the last).
